### PR TITLE
Fix un-escaped path provided to lps2bpes

### DIFF
--- a/mcrl2-mode.el
+++ b/mcrl2-mode.el
@@ -154,7 +154,7 @@
 (defun mcf-create-lps-pbes (&optional set-line)
   (interactive)
   (mcrl2-cmd (concat "lps2pbes -c "
-                     (read-file-name "Enter .lps file name:")
+                     (shell-quote-argument (read-file-name "Enter .lps file name:"))
                      " -f " (shell-quote-argument buffer-file-name)
                      " " (shell-quote-argument (concat buffer-file-name ".pbes")) )))
 


### PR DESCRIPTION
This PR fixes the issue described in #1.